### PR TITLE
Fix typo in parameters that causes no output filename to be specified

### DIFF
--- a/ghostscript_fuzzer.c
+++ b/ghostscript_fuzzer.c
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
         "-q",
         "-dSAFER",
         "-dNODISPLAY",
-        "-dOutputFile=/dev/null",
+        "-sOutputFile=/dev/null",
         "-sstdout=/dev/null",
         "-dBATCH",
         "-dNOPAUSE",


### PR DESCRIPTION
There is an issue in the fuzzer which appears to be a typo or an oversight.  You have the parameter -dOutputFile and it should be -sOutputFile according to Artifex Software; otherwise no output filename is set.